### PR TITLE
add passwords to User create

### DIFF
--- a/spec/models/attraction_spec.rb
+++ b/spec/models/attraction_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Attraction, :type => :model do
   end
 
   it "has many users through rides" do
-    max = User.create(name: "Max Charles")
-    skai = User.create(name: "Skai Jackson")
+    max = User.create(name: "Max Charles", password: "password")
+    skai = User.create(name: "Skai Jackson", password: "password")
     @attraction.users << [max, skai]
     expect(@attraction.users.first).to eq(max)
     expect(@attraction.users.last).to eq(skai)


### PR DESCRIPTION
The instructions suggest using `has_secure_password` in the User model, but the test "has many users through rides" in the attraction_spec fails even when the code is correct. This is because Users are required to have passwords, but the test tries to create Users without passwords. Adding a password fixes the issue.
