### PR TITLE
Create test users with password

### DIFF
--- a/spec/models/attraction_spec.rb
+++ b/spec/models/attraction_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Attraction, :type => :model do
   end
 
   it "has many users through rides" do
-    max = User.create(name: "Max Charles")
-    skai = User.create(name: "Skai Jackson")
+    max = User.create(name: "Max Charles", password: "password")
+    skai = User.create(name: "Skai Jackson", password: "password")
     @attraction.users << [max, skai]
     expect(@attraction.users.first).to eq(max)
     expect(@attraction.users.last).to eq(skai)


### PR DESCRIPTION
The [user model specs](https://github.com/learn-co-curriculum/rails-amusement-park/blob/master/spec/models/user_spec.rb#L51) require a user to have a password. Causing validations to fail for test users created without a password `Validation failed: Password can't be blank`
